### PR TITLE
fix: correct solid-js peer dep version range

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Render SolidJS components in Vitest Browser Mode. This library follows `testing-
 
 Requires `vitest` >= 4.0.0, `@vitest/browser` >= 4.0.0, and `solid-js` >= 1.8.0.
 
-Tested and developed using `vitest` 4.0.2, `@vitest/browser` 4.0.2, and `solid-js` 1.9.9.
+Tested and developed using `vitest` 4.0.2, `@vitest/browser` 4.0.2, and `solid-js` 1.9.10.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -54,23 +54,24 @@
   },
   "peerDependencies": {
     "@vitest/browser": "^4.0.0",
-    "solid-js": "1.9.9",
+    "solid-js": "^1.8.0",
     "vitest": "^4.0.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "6.0.0",
     "@vitest/browser": "4.0.2",
-    "@vitest/browser-playwright": "^4.0.2",
+    "@vitest/browser-playwright": "4.0.2",
     "bumpp": "10.3.1",
     "changelogithub": "13.16.0",
     "esbuild-plugin-solid": "0.6.0",
     "eslint": "9.38.0",
     "playwright": "1.56.1",
+    "solid-js": "1.9.10",
     "tsup": "8.5.0",
     "tsx": "4.20.6",
     "typescript": "5.9.3",
     "vite-plugin-solid": "2.11.10",
-    "zx": "8.8.5",
-    "vitest": "4.0.2"
+    "vitest": "4.0.2",
+    "zx": "8.8.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      solid-js:
-        specifier: 1.9.9
-        version: 1.9.9
     devDependencies:
       '@antfu/eslint-config':
         specifier: 6.0.0
@@ -19,7 +15,7 @@ importers:
         specifier: 4.0.2
         version: 4.0.2(vite@6.2.5(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.2(@types/debug@4.1.12)(@vitest/browser-playwright@4.0.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))
       '@vitest/browser-playwright':
-        specifier: ^4.0.2
+        specifier: 4.0.2
         version: 4.0.2(playwright@1.56.1)(vite@6.2.5(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.2)
       bumpp:
         specifier: 10.3.1
@@ -29,13 +25,16 @@ importers:
         version: 13.16.0
       esbuild-plugin-solid:
         specifier: 0.6.0
-        version: 0.6.0(esbuild@0.25.2)(solid-js@1.9.9)
+        version: 0.6.0(esbuild@0.25.2)(solid-js@1.9.10)
       eslint:
         specifier: 9.38.0
         version: 9.38.0(jiti@2.6.1)
       playwright:
         specifier: 1.56.1
         version: 1.56.1
+      solid-js:
+        specifier: 1.9.10
+        version: 1.9.10
       tsup:
         specifier: 8.5.0
         version: 8.5.0(jiti@2.6.1)(postcss@8.5.3)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -47,7 +46,7 @@ importers:
         version: 5.9.3
       vite-plugin-solid:
         specifier: 2.11.10
-        version: 2.11.10(solid-js@1.9.9)(vite@6.2.5(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))
+        version: 2.11.10(solid-js@1.9.10)(vite@6.2.5(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))
       vitest:
         specifier: 4.0.2
         version: 4.0.2(@types/debug@4.1.12)(@vitest/browser-playwright@4.0.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1)
@@ -2298,8 +2297,8 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  solid-js@1.9.9:
-    resolution: {integrity: sha512-A0ZBPJQldAeGCTW0YRYJmt7RCeh5rbFfPZ2aOttgYnctHE7HgKeHCBB/PVc2P7eOfmNXqMFFFoYYdm3S4dcbkA==}
+  solid-js@1.9.10:
+    resolution: {integrity: sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==}
 
   solid-refresh@0.6.3:
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
@@ -3852,13 +3851,13 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
-  esbuild-plugin-solid@0.6.0(esbuild@0.25.2)(solid-js@1.9.9):
+  esbuild-plugin-solid@0.6.0(esbuild@0.25.2)(solid-js@1.9.10):
     dependencies:
       '@babel/core': 7.26.10
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
       babel-preset-solid: 1.9.5(@babel/core@7.26.10)
       esbuild: 0.25.2
-      solid-js: 1.9.9
+      solid-js: 1.9.10
     transitivePeerDependencies:
       - supports-color
 
@@ -5168,18 +5167,18 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  solid-js@1.9.9:
+  solid-js@1.9.10:
     dependencies:
       csstype: 3.1.3
       seroval: 1.3.2
       seroval-plugins: 1.3.3(seroval@1.3.2)
 
-  solid-refresh@0.6.3(solid-js@1.9.9):
+  solid-refresh@0.6.3(solid-js@1.9.10):
     dependencies:
       '@babel/generator': 7.27.0
       '@babel/helper-module-imports': 7.25.9
       '@babel/types': 7.27.0
-      solid-js: 1.9.9
+      solid-js: 1.9.10
     transitivePeerDependencies:
       - supports-color
 
@@ -5398,14 +5397,14 @@ snapshots:
 
   validate-html-nesting@1.2.2: {}
 
-  vite-plugin-solid@2.11.10(solid-js@1.9.9)(vite@6.2.5(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1)):
+  vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@6.2.5(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       '@babel/core': 7.26.10
       '@types/babel__core': 7.20.5
       babel-preset-solid: 1.9.5(@babel/core@7.26.10)
       merge-anything: 5.1.7
-      solid-js: 1.9.9
-      solid-refresh: 0.6.3(solid-js@1.9.9)
+      solid-js: 1.9.10
+      solid-refresh: 0.6.3(solid-js@1.9.10)
       vite: 6.2.5(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1)
       vitefu: 1.0.6(vite@6.2.5(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))
     transitivePeerDependencies:


### PR DESCRIPTION
`solid-js` v1.9.10 has been released, and I got the following warning in my project:

```
└─┬ vitest-browser-solid 1.0.0
  └── ✕ unmet peer solid-js@1.9.9: found 1.9.10
```

The `peerDependencies` in `vitest-browser-solid`'s package.json should be a version range instead of a fixed version. You can add `"solid-js": "1.9.10"` in `devDependencies` to install the latest version of `solid-js`.